### PR TITLE
rewind after read

### DIFF
--- a/lib/rack/github_webhooks.rb
+++ b/lib/rack/github_webhooks.rb
@@ -34,6 +34,12 @@ module Rack
         env['rack.input'].read
       )
       return [400, {}, ["Signatures didn't match!"]] unless signature.valid?
+
+      begin
+        env['rack.input'].rewind if env['rack.input'].respond_to?(:rewind)
+      rescue Errno::ESPIPE
+      end
+
       @app.call(env)
     end
   end


### PR DESCRIPTION
After we introduce this gem into our project, we'll need to `env['rack.input'].rewind` before `env['rack.input'].read`.

I added `env['rack.input'].rewind` before `@app.call(env)`. 
