### PR TITLE
Validate using SHA256 instead of SHA1

### DIFF
--- a/lib/rack/github_webhooks.rb
+++ b/lib/rack/github_webhooks.rb
@@ -5,12 +5,12 @@ require 'json'
 module Rack
   class GithubWebhooks
     class Signature
-      HMAC_DIGEST = OpenSSL::Digest.new('sha1')
+      HMAC_DIGEST = OpenSSL::Digest.new('sha256')
 
       def initialize(secret, hub_signature, payload_body)
         @secret = secret
         @hub_signature = hub_signature
-        @signature = "sha1=#{OpenSSL::HMAC.hexdigest(HMAC_DIGEST, secret, payload_body)}"
+        @signature = "sha256=#{OpenSSL::HMAC.hexdigest(HMAC_DIGEST, secret, payload_body)}"
       end
 
       def valid?
@@ -29,7 +29,7 @@ module Rack
       rewind_body(env)
       signature = Signature.new(
         @secret,
-        env['HTTP_X_HUB_SIGNATURE'],
+        env['HTTP_X_HUB_SIGNATURE_256'],
         env['rack.input'].read
       )
       return [400, {}, ["Signatures didn't match!"]] unless signature.valid?

--- a/rack-github_webhooks.gemspec
+++ b/rack-github_webhooks.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.10'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'bundler', '>= 1.10'
+  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rack-test'

--- a/test/rack/github_webhooks_test.rb
+++ b/test/rack/github_webhooks_test.rb
@@ -1,12 +1,12 @@
 require 'test_helper'
 
 class RackGithubWebhooksTest < Minitest::Test
-  HMAC_DIGEST = OpenSSL::Digest.new('sha1')
+  HMAC_DIGEST = OpenSSL::Digest.new('sha256')
 
   include Rack::Test::Methods
 
   def body_signature(body)
-    'sha1=' + OpenSSL::HMAC.hexdigest(
+    'sha256=' + OpenSSL::HMAC.hexdigest(
       HMAC_DIGEST,
       's3cret',
       body
@@ -27,14 +27,14 @@ class RackGithubWebhooksTest < Minitest::Test
   def test_invalid_signature
     post '/',
       '{}',
-      'HTTP_X_HUB_SIGNATURE' => 'sha1=invalid'
+      'HTTP_X_HUB_SIGNATURE_256' => 'sha256=invalid'
     assert_equal 400, last_response.status
     assert_equal "Signatures didn't match!", last_response.body
   end
 
   def test_valid_signature
     body = '{}'
-    post '/', body, 'HTTP_X_HUB_SIGNATURE' => body_signature(body)
+    post '/', body, 'HTTP_X_HUB_SIGNATURE_256' => body_signature(body)
     assert_equal 200, last_response.status
     assert_equal 'ok', last_response.body
   end
@@ -47,7 +47,7 @@ class RackGithubWebhooksTest < Minitest::Test
 
   def test_post_body
     body = '{content: "text"}'
-    post '/', body, 'HTTP_X_HUB_SIGNATURE' => body_signature(body)
+    post '/', body, 'HTTP_X_HUB_SIGNATURE_256' => body_signature(body)
     assert_equal body, last_request.body.read
   end
 end


### PR DESCRIPTION
As described in https://docs.github.com/en/github-ae@latest/developers/webhooks-and-events/webhooks/securing-your-webhooks#validating-payloads-from-github

Closes https://github.com/chrismytton/rack-github_webhooks/issues/2