### PR TITLE
Require rack/builder to fix tests run

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,4 +6,5 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'rack/github_webhooks'
 
 require 'minitest/autorun'
+require 'rack/builder'
 require 'rack/test'


### PR DESCRIPTION
Hi, I just downloaded and tried to run tests on my Linux, Ruby 3.2 setup and the tests failed with:

```
RackGithubWebhooksTest#test_invalid_signature:
NameError: uninitialized constant Rack::Builder
    /Users/megatux/code/rack-github_webhooks/test/rack/github_webhooks_test.rb:17:in `app'
...
```
I require the `rack/builder` and it seems fixed, at least here.